### PR TITLE
Update to README with more specific Blazor install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add this line to the bottom of your `App.razor` file:
 <script type="module" src="@Assets["_content/Dorset-Council-UK.GdsBlazorComponents/gds.js"]"></script>
 ```
 
-## Blazor Webassembly: 
+## Blazor WebAssembly: 
 Add this line to the top of your `index.html` file:
 ```html
 <head>


### PR DESCRIPTION
I know it might be a bit of a "suck eggs" update to the readme but it might be helpful to someone else getting it up and running. 

I've also added a few lines to differentiate between Blazor Webapp and Blazor Webassembly standalone, as the syntax for the install is slightly different for each as well as the location of where the lines need adding.  