### PR TITLE
New layout components

### DIFF
--- a/GdsBlazorComponents/Examples/Breadcrumbs.md
+++ b/GdsBlazorComponents/Examples/Breadcrumbs.md
@@ -18,13 +18,13 @@ Render GOV.UK Design System styled breadcrumbs that are defined per page and ren
 ```csharp
 @using Microsoft.AspNetCore.Components.Sections
 
-<div class="govuk-width-container">
+<GdsContainer>
     <SectionOutlet SectionName="Layout.GdsBreadcrumbs" />
 
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
         @Body
     </main>
-</div>
+</GdsContainer>
 
 ```
 

--- a/GdsBlazorComponents/Examples/Breadcrumbs.md
+++ b/GdsBlazorComponents/Examples/Breadcrumbs.md
@@ -21,9 +21,9 @@ Render GOV.UK Design System styled breadcrumbs that are defined per page and ren
 <GdsContainer>
     <SectionOutlet SectionName="Layout.GdsBreadcrumbs" />
 
-    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+    <GdsMainWrapper id="main-content" AdditionalCssClasses="govuk-body">
         @Body
-    </main>
+    </GdsMainWrapper>
 </GdsContainer>
 
 ```

--- a/GdsBlazorComponents/Examples/Checkboxes.md
+++ b/GdsBlazorComponents/Examples/Checkboxes.md
@@ -49,7 +49,7 @@ ICollection<GdsOptionItem<int>> contactTypes = [
 <GdsFormGroup For="() => Model.ContactType">
     <GdsFieldsetGroup>
         <Heading>
-            <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
+            <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
         </Heading>
         <Content>
             <GdsHint>Select all that apply.</GdsHint>
@@ -72,7 +72,7 @@ ICollection<GdsOptionItem<int>> contactTypes = [
 <GdsFormGroup For="() => Model.ContactType">
     <GdsFieldsetGroup>
         <Heading>
-            <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
+            <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
         </Heading>
         <Content>
             <GdsHint>Select all that apply.</GdsHint>

--- a/GdsBlazorComponents/Examples/Container.md
+++ b/GdsBlazorComponents/Examples/Container.md
@@ -17,7 +17,7 @@ Render GOV.UK Design System styled container.
 ```
 
 ```csharp
-<GdsContainer AdditionalCssClasses="flex-fill">
+<GdsContainer AdditionalCssClasses="govuk-!-margin-bottom-6">
     <div>Container example</div>
 </GdsContainer>
 ```

--- a/GdsBlazorComponents/Examples/Container.md
+++ b/GdsBlazorComponents/Examples/Container.md
@@ -1,0 +1,29 @@
+# Container
+
+Render GOV.UK Design System styled container.
+
+## How it works
+
+- renders a `<div class="govuk-width-container` element styled according to the GOV.UK Design System.
+- optional `AdditionalCssClasses` parameter to add additional CSS classes to the container element
+- any additional HTML attributes passed to the component will be added to the container element
+
+## Examples
+
+```csharp
+<GdsContainer>
+    <div>Container example</div>
+</GdsContainer>
+```
+
+```csharp
+<GdsContainer AdditionalCssClasses="flex-fill">
+    <div>Container example</div>
+</GdsContainer>
+```
+
+```csharp
+<GdsContainer id="my-container" data-something="testing">
+    <div>Container example</div>
+</GdsContainer>
+```

--- a/GdsBlazorComponents/Examples/FieldsetGroup.md
+++ b/GdsBlazorComponents/Examples/FieldsetGroup.md
@@ -18,7 +18,7 @@ See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examp
 ```csharp
 <GdsFieldsetGroup>
     <Heading>
-        <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
+        <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
     </Heading>
 </GdsFieldsetGroup>
 ```
@@ -28,7 +28,7 @@ See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examp
 ```csharp
 <GdsFieldsetGroup LegendSize="GdsSize.Medium">
     <Heading>
-        <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
+        <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
     </Heading>
     <Content>
         <div>Anything can go here.</div>

--- a/GdsBlazorComponents/Examples/FieldsetGroup.md
+++ b/GdsBlazorComponents/Examples/FieldsetGroup.md
@@ -7,9 +7,11 @@ Render a GOV.UK Design System styled fieldset that associates with a form contro
 - Renders ```<fieldset class="govuk-fieldset">``` with any child content you provide.
 - An optional heading can be provided using the `Heading` parameter.
   - This will be wrapped in a legend element with the correct GDS classes.
-  - You can change the size of the legend using the `LegendSize` parameter.
+  - You can change the size of the legend using the `LegendTextSize` parameter.
 - The component tries to calculate aria-describedby based on hint and field errors.
 - It is recommended to use this component within a [GdsFormGroup](FormGroup.md) to fully support correct HTML and accessibility.
+
+*Warning:* `LegendSize` was deprecated in version 3.3.0 use `LegendTextSize` instead. `LegendSize` will be removed in a future release.
 
 See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examples of using this component.
 
@@ -26,7 +28,7 @@ See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examp
 ## Example
 
 ```csharp
-<GdsFieldsetGroup LegendSize="GdsSize.Medium">
+<GdsFieldsetGroup LegendTextSize="GdsSize.Medium">
     <Heading>
         <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
     </Heading>

--- a/GdsBlazorComponents/Examples/FieldsetGroup.md
+++ b/GdsBlazorComponents/Examples/FieldsetGroup.md
@@ -7,7 +7,7 @@ Render a GOV.UK Design System styled fieldset that associates with a form contro
 - Renders ```<fieldset class="govuk-fieldset">``` with any child content you provide.
 - An optional heading can be provided using the `Heading` parameter.
   - This will be wrapped in a legend element with the correct GDS classes.
-  - You can change the size of the legend using the `LegendSize` GdsFieldsetGroup parameter.
+  - You can change the size of the legend using the `LegendSize` parameter.
 - The component tries to calculate aria-describedby based on hint and field errors.
 - It is recommended to use this component within a [GdsFormGroup](FormGroup.md) to fully support correct HTML and accessibility.
 
@@ -26,7 +26,7 @@ See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examp
 ## Example
 
 ```csharp
-<GdsFieldsetGroup LegendSize="GdsFieldsetLegendSize.Medium">
+<GdsFieldsetGroup LegendSize="GdsSize.Medium">
     <Heading>
         <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
     </Heading>

--- a/GdsBlazorComponents/Examples/Footer.md
+++ b/GdsBlazorComponents/Examples/Footer.md
@@ -44,42 +44,42 @@ Full examples from the GOV.UK Design System can be at [Footer with links and sec
 <GdsFooter>
     <Navigation>
         <GdsFooterSection Width="GdsGridColumnWidth.TwoThirds">
-            <h2 class="govuk-footer__heading govuk-heading-m">Two column list</h2>
-                <ul class="govuk-footer__list govuk-footer__list--columns-2">
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 1</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 2</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 3</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 4</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 5</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 6</a>
-                    </li>
-                </ul>
-            </GdsFooterSection>
-            <GdsFooterSection Width="GdsGridColumnWidth.OneThird">
-                <h2 class="govuk-footer__heading govuk-heading-m">Single column list</h2>
-                <ul class="govuk-footer__list">
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 1</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 2</a>
-                    </li>
-                    <li class="govuk-footer__list-item">
-                        <a class="govuk-footer__link" href="#">Navigation item 3</a>
-                    </li>
-                </ul>
-            </GdsFooterSection>
-        </Navigation>
+            <GdsHeading Level="2" Size="GdsSize.Medium" AdditionalCssClasses="govuk-footer__heading">Two column list</GdsHeading>
+            <ul class="govuk-footer__list govuk-footer__list--columns-2">
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 1</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 2</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 3</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 4</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 5</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 6</a>
+                </li>
+            </ul>
+        </GdsFooterSection>
+        <GdsFooterSection Width="GdsGridColumnWidth.OneThird">
+            <GdsHeading Level="2" Size="GdsSize.Medium" AdditionalCssClasses="govuk-footer__heading">Single column list</GdsHeading>
+            <ul class="govuk-footer__list">
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 1</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 2</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#">Navigation item 3</a>
+                </li>
+            </ul>
+        </GdsFooterSection>
+    </Navigation>
 </GdsFooter>
 ```

--- a/GdsBlazorComponents/Examples/Footer.md
+++ b/GdsBlazorComponents/Examples/Footer.md
@@ -12,7 +12,7 @@ Allowing you to use your own content in the footer, via the GDS `Navigation` and
 
 - Renders a ```<footer class="govuk-footer">``` element.
 - Supports flexible `Navigation` and `Meta` optional sections.
-- The navigation section typically uses columns of links with `govuk-footer__section` and `govuk-footer__list`.
+- For navigation columns use the `<GdsFooterSection>` component.
 - The meta section supports multiple types of meta items with `govuk-footer__meta-item` examples include:
   - open government licence
   - support links with `govuk-footer__list`
@@ -35,5 +35,51 @@ Full examples from the GOV.UK Design System can be at [Footer with links and sec
             <div>Copyright &copy; @(DateTimeOffset.UtcNow.Year) Your company</div>
         </div>
     </Meta>
+</GdsFooter>
+```
+
+## Example - Navigation columns
+
+```csharp
+<GdsFooter>
+    <Navigation>
+        <GdsFooterSection Width="GdsGridColumnWidth.TwoThirds">
+            <h2 class="govuk-footer__heading govuk-heading-m">Two column list</h2>
+                <ul class="govuk-footer__list govuk-footer__list--columns-2">
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 1</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 2</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 3</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 4</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 5</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 6</a>
+                    </li>
+                </ul>
+            </GdsFooterSection>
+            <GdsFooterSection Width="GdsGridColumnWidth.OneThird">
+                <h2 class="govuk-footer__heading govuk-heading-m">Single column list</h2>
+                <ul class="govuk-footer__list">
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 1</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 2</a>
+                    </li>
+                    <li class="govuk-footer__list-item">
+                        <a class="govuk-footer__link" href="#">Navigation item 3</a>
+                    </li>
+                </ul>
+            </GdsFooterSection>
+        </Navigation>
 </GdsFooter>
 ```

--- a/GdsBlazorComponents/Examples/FooterSection.md
+++ b/GdsBlazorComponents/Examples/FooterSection.md
@@ -1,0 +1,17 @@
+# Footer section
+
+Render GOV.UK Design System styled footer section for use within the `GdsFooter` component.
+
+## How it works
+- renders and wraps a `GdsGridColumn` component for use in GOV.UK Design System footer navigation
+- use the `Width` parameter to specify the width of the footer section, for example: `Width="GdsGridColumnWidth.TwoThirds"` or `Width="GdsGridColumnWidth.TwoThirdsFromDesktop"`
+- for a combination of GDS widths use the `Widths` parameter, for example: `Widths="[GdsGridColumnWidth.TwoThirds, GdsGridColumnWidth.OneHalfFromDesktop]"`
+- if no width is specified, the footer section will default to full width
+- optional `AdditionalCssClasses` parameter to add additional CSS classes to the footer section element
+- any additional HTML attributes passed to the component will be added to the footer section element
+
+## Examples
+
+See the [Footer](Footer.md) component for examples of how to use the `GdsFooterSection` component within a footer.
+
+See the [GridColumn](GridColumn.md) component for examples of how to set the width and additional parameters.

--- a/GdsBlazorComponents/Examples/FormGroup.md
+++ b/GdsBlazorComponents/Examples/FormGroup.md
@@ -46,9 +46,9 @@ The ID of `phone-number` on the `GdsFormGroup` is cascaded down to:
 
 ```csharp
 <GdsFormGroup For="() => Model.OtherAction" AdditionalCssClasses="govuk-character-count govuk-!-margin-top-4" DataModule="govuk-character-count" DataMaxLength="100">
-    <h2 class="govuk-label-wrapper">
+    <GdsHeading Level="2" class="govuk-label-wrapper">
         <GdsLabel Text="Can you provide more details?" AdditionalCssClasses="govuk-label--m" />
-    </h2>
+    </GdsHeading>
     <GdsHint>Do not include personal or financial information</GdsHint>
     <GdsErrorMessage />
     <InputTextArea id="@nameof(Model.OtherAction)" @bind-Value="Model.OtherAction" class="govuk-textarea govuk-js-character-count" rows="5" />

--- a/GdsBlazorComponents/Examples/GridColumn.md
+++ b/GdsBlazorComponents/Examples/GridColumn.md
@@ -1,0 +1,28 @@
+# Grid column
+
+Render GOV.UK Design System styled grid column.
+
+## How it works
+- renders a `<div class="govuk-grid-column` element styled according to the GOV.UK Design System
+- use the `Width` parameter to specify the width of the column, for example: `Width="GdsGridColumnWidth.TwoThirds"` or `Width="GdsGridColumnWidth.TwoThirdsFromDesktop"`
+- for a combination of GDS widths use the `Widths` parameter, for example: `Widths="[GdsGridColumnWidth.TwoThirds, GdsGridColumnWidth.OneHalfFromDesktop]"`
+- if no width is specified, the column will default to full width
+- optional `AdditionalCssClasses` parameter to add additional CSS classes to the column element
+- any additional HTML attributes passed to the component will be added to the column element
+
+## Widths
+- Full
+- OneHalf
+- OneHalfFromDesktop
+- OneThird
+- OneThirdFromDesktop
+- TwoThirds
+- TwoThirdsFromDesktop
+- OneQuarter
+- OneQuarterFromDesktop
+- ThreeQuarters
+- ThreeQuartersFromDesktop
+
+## Examples
+
+See the [GridRow](GridRow.md) component for examples of how to use the `GdsGridColumn` component within a grid row.

--- a/GdsBlazorComponents/Examples/GridRow.md
+++ b/GdsBlazorComponents/Examples/GridRow.md
@@ -12,39 +12,39 @@ Render GOV.UK Design System styled grid row.
 
 ```csharp
 <GdsGridRow>
-    <div class="govuk-grid-column-two-thirds">
+    <GdsGridColumn Width="GdsGridColumnWidth.TwoThirds">
         <h1 class="govuk-heading-xl">Two-thirds column</h1>
         <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
-    </div>
-    <div class="govuk-grid-column-one-third">
+    </GdsGridColumn>
+    <GdsGridColumn Width="GdsGridColumnWidth.OneThird">
         <h2 class="govuk-heading-m">One-third column</h2>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
-    </div>
+    </GdsGridColumn>
 </GdsGridRow>
 ```
 
 ```csharp
 <GdsGridRow AdditionalCssClasses="govuk-!-padding-bottom-6">
-    <div class="govuk-grid-column-two-thirds">
+    <GdsGridColumn Width="GdsGridColumnWidth.TwoThirds">
         <h1 class="govuk-heading-xl">Two-thirds column</h1>
         <p class="govuk-body">A two-thirds wide column with additional CSS classes</p>
-    </div>
-    <div class="govuk-grid-column-one-third">
+    </GdsGridColumn>
+    <GdsGridColumn Width="GdsGridColumnWidth.OneThird">
         <h2 class="govuk-heading-m">One-third column</h2>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
-    </div>
+    </GdsGridColumn>
 </GdsGridRow>
 ```
 
 ```csharp
 <GdsGridRow id="my-row" data-something="testing">
-    <div class="govuk-grid-column-two-thirds">
+    <GdsGridColumn Widths="[GdsGridColumnWidth.TwoThirds, GdsGridColumnWidth.OneHalfFromDesktop]">
         <h1 class="govuk-heading-xl">Two-thirds column</h1>
         <p class="govuk-body">A two-thirds wide column with additional HTML attributes</p>
-    </div>
-    <div class="govuk-grid-column-one-third">
+    </GdsGridColumn>
+    <GdsGridColumn Widths="[GdsGridColumnWidth.OneThird, GdsGridColumnWidth.OneHalfFromDesktop]">
         <h2 class="govuk-heading-m">One-third column</h2>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
-    </div>
+    </GdsGridColumn>
 </GdsGridRow>
 ```

--- a/GdsBlazorComponents/Examples/GridRow.md
+++ b/GdsBlazorComponents/Examples/GridRow.md
@@ -1,0 +1,50 @@
+# Grid Row
+
+Render GOV.UK Design System styled grid row.
+
+## How it works
+
+- renders a `<div class="govuk-grid-row` element styled according to the GOV.UK Design System.
+- optional `AdditionalCssClasses` parameter to add additional CSS classes to the container element
+- any additional HTML attributes passed to the component will be added to the container element
+
+## Examples
+
+```csharp
+<GdsGridRow>
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Two-thirds column</h1>
+        <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <h2 class="govuk-heading-m">One-third column</h2>
+        <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
+    </div>
+</GdsGridRow>
+```
+
+```csharp
+<GdsGridRow AdditionalCssClasses="govuk-!-padding-bottom-6">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Two-thirds column</h1>
+        <p class="govuk-body">A two-thirds wide column with additional CSS classes</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <h2 class="govuk-heading-m">One-third column</h2>
+        <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
+    </div>
+</GdsGridRow>
+```
+
+```csharp
+<GdsGridRow id="my-row" data-something="testing">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Two-thirds column</h1>
+        <p class="govuk-body">A two-thirds wide column with additional HTML attributes</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <h2 class="govuk-heading-m">One-third column</h2>
+        <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
+    </div>
+</GdsGridRow>
+```

--- a/GdsBlazorComponents/Examples/GridRow.md
+++ b/GdsBlazorComponents/Examples/GridRow.md
@@ -13,11 +13,11 @@ Render GOV.UK Design System styled grid row.
 ```csharp
 <GdsGridRow>
     <GdsGridColumn Width="GdsGridColumnWidth.TwoThirds">
-        <h1 class="govuk-heading-xl">Two-thirds column</h1>
+        <GdsHeading Level="1">Two-thirds column</GdsHeading>
         <p class="govuk-body">This is a paragraph inside a two-thirds wide column</p>
     </GdsGridColumn>
     <GdsGridColumn Width="GdsGridColumnWidth.OneThird">
-        <h2 class="govuk-heading-m">One-third column</h2>
+        <GdsHeading Level="2" Size="GdsSize.Medium">One-third column</GdsHeading>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
     </GdsGridColumn>
 </GdsGridRow>
@@ -26,11 +26,11 @@ Render GOV.UK Design System styled grid row.
 ```csharp
 <GdsGridRow AdditionalCssClasses="govuk-!-padding-bottom-6">
     <GdsGridColumn Width="GdsGridColumnWidth.TwoThirds">
-        <h1 class="govuk-heading-xl">Two-thirds column</h1>
+        <GdsHeading Level="1">Two-thirds column</GdsHeading>
         <p class="govuk-body">A two-thirds wide column with additional CSS classes</p>
     </GdsGridColumn>
     <GdsGridColumn Width="GdsGridColumnWidth.OneThird">
-        <h2 class="govuk-heading-m">One-third column</h2>
+        <GdsHeading Level="2" Size="GdsSize.Medium">One-third column</GdsHeading>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
     </GdsGridColumn>
 </GdsGridRow>
@@ -39,11 +39,11 @@ Render GOV.UK Design System styled grid row.
 ```csharp
 <GdsGridRow id="my-row" data-something="testing">
     <GdsGridColumn Widths="[GdsGridColumnWidth.TwoThirds, GdsGridColumnWidth.OneHalfFromDesktop]">
-        <h1 class="govuk-heading-xl">Two-thirds column</h1>
+        <GdsHeading Level="1">Two-thirds column</GdsHeading>
         <p class="govuk-body">A two-thirds wide column with additional HTML attributes</p>
     </GdsGridColumn>
     <GdsGridColumn Widths="[GdsGridColumnWidth.OneThird, GdsGridColumnWidth.OneHalfFromDesktop]">
-        <h2 class="govuk-heading-m">One-third column</h2>
+        <GdsHeading Level="2" Size="GdsSize.Medium">One-third column</GdsHeading>
         <p class="govuk-body">This is a paragraph inside a one-third wide column</p>
     </GdsGridColumn>
 </GdsGridRow>

--- a/GdsBlazorComponents/Examples/Header.md
+++ b/GdsBlazorComponents/Examples/Header.md
@@ -48,11 +48,11 @@ This component is intentionally restrictive. If you need more control over the h
 <body class="govuk-template__body">
   <GdsHeader ServiceName="My Service" ServiceUrl="home" LogoUrl="@Assets["images/logos/logo.webp"]" />
 
-  <div class="govuk-width-container">
+  <GdsContainer>
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
       @Body
     </main>
-  </div>
+  </GdsContainer>
 
   <GdsFooter />
 </body>
@@ -77,11 +77,11 @@ This works similar to how Blazor NavLink components function, with the `Href` pa
             </AuthorizeView>
         </NavLinks>
     </GdsHeader>
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-      @Body
-    </main>
-  </div>
+    <GdsContainer>
+        <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+            @Body
+        </main>
+    </GdsContainer>
 
-  <GdsFooter />
+    <GdsFooter />
 </body>

--- a/GdsBlazorComponents/Examples/Header.md
+++ b/GdsBlazorComponents/Examples/Header.md
@@ -49,9 +49,9 @@ This component is intentionally restrictive. If you need more control over the h
   <GdsHeader ServiceName="My Service" ServiceUrl="home" LogoUrl="@Assets["images/logos/logo.webp"]" />
 
   <GdsContainer>
-    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+    <GdsMainWrapper id="main-content" AdditionalCssClasses="govuk-body">
       @Body
-    </main>
+    </GdsMainWrapper>
   </GdsContainer>
 
   <GdsFooter />
@@ -78,10 +78,11 @@ This works similar to how Blazor NavLink components function, with the `Href` pa
         </NavLinks>
     </GdsHeader>
     <GdsContainer>
-        <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+        <GdsMainWrapper id="main-content" AdditionalCssClasses="govuk-body">
             @Body
-        </main>
+        </GdsMainWrapper>
     </GdsContainer>
 
     <GdsFooter />
 </body>
+```

--- a/GdsBlazorComponents/Examples/Heading.md
+++ b/GdsBlazorComponents/Examples/Heading.md
@@ -5,27 +5,33 @@ Render GOV.UK Design System styled heading.
 ## How it works
 - renders a `<h1>` to `<h6>` heading element styled according to the GOV.UK Design System
 - use the `Level` parameter to specify the heading level 1 to 6
-- use the `Size` parameter to specify the heading size (small, medium, large, extra large)
+- use the `Size` parameter to override the automatic heading size (small, medium, large, extra large)
 - if no size is specified, the heading will default to extra large size
 - optional `AdditionalCssClasses` parameter to add additional CSS classes to the heading element
 - any additional HTML attributes passed to the component will be added to the heading element
 
 ## Size
-- Small
-- Medium
-- Large
 - ExtraLarge
+- Large
+- Medium
+- Small
+
+## Automatic size by heading level
+- Level 1: Extra Large
+- Level 2: Large
+- Level 3: Medium
+- Level 4, 5, 6: Small
 
 ## Examples
 
 ```csharp
-<GdsHeading Level="1">Extra large heading</GdsHeading>
+<GdsHeading Level="1">Heading 1</GdsHeading>
 ```
 
 ```csharp
-<GdsHeading Level="2" Size="GdsSize.Large">Large heading</GdsHeading>
+<GdsHeading Level="2">Heading 2</GdsHeading>
 ```
 
 ```csharp
-<GdsHeading Level="3" Size="GdsSize.Medium">Medium heading</GdsHeading>
+<GdsHeading Level="3" Size="GdsSize.Small">Heading 3 - Overridden size</GdsHeading>
 ```

--- a/GdsBlazorComponents/Examples/Heading.md
+++ b/GdsBlazorComponents/Examples/Heading.md
@@ -6,7 +6,6 @@ Render GOV.UK Design System styled heading.
 - renders a `<h1>` to `<h6>` heading element styled according to the GOV.UK Design System
 - use the `Level` parameter to specify the heading level 1 to 6
 - use the `Size` parameter to override the automatic heading size (small, medium, large, extra large)
-- if no size is specified, the heading will default to extra large size
 - optional `AdditionalCssClasses` parameter to add additional CSS classes to the heading element
 - any additional HTML attributes passed to the component will be added to the heading element
 

--- a/GdsBlazorComponents/Examples/Heading.md
+++ b/GdsBlazorComponents/Examples/Heading.md
@@ -1,0 +1,31 @@
+# Heading
+
+Render GOV.UK Design System styled heading.
+
+## How it works
+- renders a `<h1>` to `<h6>` heading element styled according to the GOV.UK Design System
+- use the `Level` parameter to specify the heading level 1 to 6
+- use the `Size` parameter to specify the heading size (small, medium, large, extra large)
+- if no size is specified, the heading will default to extra large size
+- optional `AdditionalCssClasses` parameter to add additional CSS classes to the heading element
+- any additional HTML attributes passed to the component will be added to the heading element
+
+## Size
+- Small
+- Medium
+- Large
+- ExtraLarge
+
+## Examples
+
+```csharp
+<GdsHeading Level="1">Extra large heading</GdsHeading>
+```
+
+```csharp
+<GdsHeading Level="2" Size="GdsSize.Large">Large heading</GdsHeading>
+```
+
+```csharp
+<GdsHeading Level="3" Size="GdsSize.Medium">Medium heading</GdsHeading>
+```

--- a/GdsBlazorComponents/Examples/InputDate.md
+++ b/GdsBlazorComponents/Examples/InputDate.md
@@ -80,7 +80,7 @@ RuleFor(o => o.StartDate)
 ```csharp
 <GdsInputDate For="() => Model.StartDate" Id="flood-start">
     <Heading>
-        <h1 class="govuk-fieldset__heading">When did the flooding start?</h1>
+        <GdsHeading Level="1" class="govuk-fieldset__heading">When did the flooding start?</GdsHeading>
     </Heading>
     <Hint>For example, 27 3 2025</Hint>
 </GdsInputDate>
@@ -91,7 +91,7 @@ RuleFor(o => o.StartDate)
 ```csharp
 <GdsInputDate For="() => Model.DateOfBirth" Id="dob" IsDateOfBirth="true">
     <Heading>
-        <h1 class="govuk-fieldset__heading">What is your date of birth?</h1>
+        <GdsHeading Level="1" class="govuk-fieldset__heading">What is your date of birth?</GdsHeading>
     </Heading>
     <Hint>For example, 27 3 1980</Hint>
 </GdsInputDate>

--- a/GdsBlazorComponents/Examples/InputPartialDate.md
+++ b/GdsBlazorComponents/Examples/InputPartialDate.md
@@ -51,7 +51,7 @@ Please see [InputDate.md](InputDate.md#validating-the-date) for more information
 ```csharp
 <GdsInputPartialDate For="() => Model.ExpiryDate" ShowMonth="true" ShowYear="true" Id="expiry">
     <Heading>
-        <h1 class="govuk-fieldset__heading">What month and year did it expire?</h1>
+        <GdsHeading Level="1" class="govuk-fieldset__heading">What month and year did it expire?</GdsHeading>
     </Heading>
     <Hint>For example, 3 2025</Hint>
 </GdsInputPartialDate>
@@ -62,7 +62,7 @@ Please see [InputDate.md](InputDate.md#validating-the-date) for more information
 ```csharp
 <GdsInputPartialDate For="() => Model.ApproxDateOfBirth" Id="dob" IsDateOfBirth="true" ShowMonth="true" ShowYear="true">
     <Heading>
-        <h1 class="govuk-fieldset__heading">What month and year were you born?</h1>
+        <GdsHeading Level="1" class="govuk-fieldset__heading">What month and year were you born?</GdsHeading>
     </Heading>
     <Hint>For example, 3 1980</Hint>
 </GdsInputPartialDate>
@@ -73,7 +73,7 @@ Please see [InputDate.md](InputDate.md#validating-the-date) for more information
 ```csharp
 <GdsInputPartialDate For="() => Model.EstimatedYear" ShowYear="true">
     <Heading>
-        <h1 class="govuk-fieldset__heading">Which year did the event occur?</h1>
+        <GdsHeading Level="1" class="govuk-fieldset__heading">Which year did the event occur?</GdsHeading>
     </Heading>
     <Hint>For example, 2025</Hint>
 </GdsInputPartialDate>

--- a/GdsBlazorComponents/Examples/MainWrapper.md
+++ b/GdsBlazorComponents/Examples/MainWrapper.md
@@ -5,7 +5,7 @@ Render GOV.UK Design System styled main wrapper element.
 ## How it works
 
 - renders a `<main class="govuk-main-wrapper` element styled according to the GOV.UK Design System.
-- use the `AutoSpacing` parameter to automatically add the GOV.UK spacing class to the container element (essentially additonal top padding)
+- use the `AutoSpacing` parameter to automatically add the GOV.UK spacing class to the container element (essentially additional top padding)
 - optional `AdditionalCssClasses` parameter to add additional CSS classes to the main wrapper element
 - any additional HTML attributes passed to the component will be added to the main wrapper element
 

--- a/GdsBlazorComponents/Examples/MainWrapper.md
+++ b/GdsBlazorComponents/Examples/MainWrapper.md
@@ -1,0 +1,28 @@
+# Main wrapper
+
+Render GOV.UK Design System styled main wrapper element.
+
+## How it works
+
+- renders a `<main class="govuk-main-wrapper` element styled according to the GOV.UK Design System.
+- use the `AutoSpacing` parameter to automatically add the GOV.UK spacing class to the container element (essentially additonal top padding)
+- optional `AdditionalCssClasses` parameter to add additional CSS classes to the main wrapper element
+- any additional HTML attributes passed to the component will be added to the main wrapper element
+
+## Examples
+
+```csharp
+<GdsContainer>
+    <GdsMainWrapper>
+        @Body
+    </GdsMainWrapper>
+</GdsContainer>
+```
+
+```csharp
+<GdsContainer>
+    <GdsMainWrapper AutoSpacing id="main-content" AdditionalCssClasses="govuk-body">
+        @Body
+    </GdsMainWrapper>
+</GdsContainer>
+```

--- a/GdsBlazorComponents/Examples/Radios.md
+++ b/GdsBlazorComponents/Examples/Radios.md
@@ -59,7 +59,7 @@ ICollection<GdsOptionItem<int>> contactTypes = [
     <InputRadioGroup @bind-Value="Model.ContactType">
         <GdsFieldsetGroup>
             <Heading>
-                <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
+                <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
             </Heading>
             <Content>
                 <GdsHint>Select all that apply.</GdsHint>
@@ -84,7 +84,7 @@ ICollection<GdsOptionItem<int>> contactTypes = [
     <InputRadioGroup @bind-Value="Model.ContactType">
         <GdsFieldsetGroup>
             <Heading>
-                <h2 class="govuk-fieldset__heading">How can we contact you?</h2>
+                <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
             </Heading>
             <Content>
                 <GdsHint>Select all that apply.</GdsHint>

--- a/GdsBlazorComponents/Examples/SkipLink.md
+++ b/GdsBlazorComponents/Examples/SkipLink.md
@@ -15,9 +15,9 @@ Render a single GOV.UK Design System styled skip link to help keyboard-only user
   <GdsSkipLink Href="#main-content" />
 
   <GdsContainer>
-    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+    <GdsMainWrapper id="main-content" AdditionalCssClasses="govuk-body">
       @Body
-    </main>
+    </GdsMainWrapper>
   </GdsContainer>
 </body>
 ```

--- a/GdsBlazorComponents/Examples/SkipLink.md
+++ b/GdsBlazorComponents/Examples/SkipLink.md
@@ -14,10 +14,10 @@ Render a single GOV.UK Design System styled skip link to help keyboard-only user
 <body class="govuk-template__body">
   <GdsSkipLink Href="#main-content" />
 
-  <div class="govuk-width-container">
+  <GdsContainer>
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
       @Body
     </main>
-  </div>
+  </GdsContainer>
 </body>
 ```

--- a/GdsBlazorComponents/Examples/Table.md
+++ b/GdsBlazorComponents/Examples/Table.md
@@ -10,8 +10,10 @@ Render a GOV.UK Design System styled table component.
 ## How it works
 
 - Renders a ```<table class="govuk-table">``` element styled according to the GOV.UK Design System.
-- Table supports `Caption`, `CaptionSize` and `FirstCellIsHeader`.
-  - Cells (`GdsTableTh` and `GdsTableTd`) support `Numeric`.
+- Table supports `Caption`, `CaptionTextSize` and `FirstCellIsHeader`.
+- Cells (`GdsTableTh` and `GdsTableTd`) support `Numeric`.
+
+*Warning:* `CaptionSize` was deprecated in version 3.3.0 use `CaptionTextSize` instead. `CaptionSize` will be removed in a future release.
 
 ## Simple example (using Formatting)
 
@@ -41,7 +43,7 @@ Render a GOV.UK Design System styled table component.
 ## Example using ChildContent
 
 ```csharp
-<GdsTable T="Member" Items="@Members" Caption="Members" CaptionSize="GdsSize.Medium" Density="GdsTableDensity.SmallTextUntilTablet">
+<GdsTable T="Member" Items="@Members" Caption="Members" CaptionTextSize="GdsSize.Medium" Density="GdsTableDensity.SmallTextUntilTablet">
     <HeaderContent>
         <GdsTableTh>Date started</GdsTableTh>
         <GdsTableTh>Full name</GdsTableTh>

--- a/GdsBlazorComponents/Examples/Table.md
+++ b/GdsBlazorComponents/Examples/Table.md
@@ -16,7 +16,7 @@ Render a GOV.UK Design System styled table component.
 ## Simple example (using Formatting)
 
 ```csharp
-<GdsTable T="Payment" Items="@Payments" Caption="Months and rates" CaptionSize="GdsTableCaptionSize.Large" FirstCellIsHeader>
+<GdsTable T="Payment" Items="@Payments" Caption="Months and rates" FirstCellIsHeader>
     <HeaderContent>
         <GdsTableTh>Month you apply</GdsTableTh>
         <GdsTableTh Numeric>Rate for vehicles</GdsTableTh>
@@ -41,7 +41,7 @@ Render a GOV.UK Design System styled table component.
 ## Example using ChildContent
 
 ```csharp
-<GdsTable T="Member" Items="@Members" Caption="Members" Density="GdsTableDensity.SmallTextUntilTablet">
+<GdsTable T="Member" Items="@Members" Caption="Members" CaptionSize="GdsSize.Medium" Density="GdsTableDensity.SmallTextUntilTablet">
     <HeaderContent>
         <GdsTableTh>Date started</GdsTableTh>
         <GdsTableTh>Full name</GdsTableTh>

--- a/GdsBlazorComponents/GdsBlazorComponents.csproj
+++ b/GdsBlazorComponents/GdsBlazorComponents.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>3.2.0</Version>
+		<Version>3.3.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Blazor components styled to match GOV.UK Design System.</Description>

--- a/GdsBlazorComponents/GdsContainer.razor
+++ b/GdsBlazorComponents/GdsContainer.razor
@@ -1,0 +1,21 @@
+<div class="@_class" @attributes="AdditionalAttributes">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        _class = $"govuk-width-container {AdditionalCssClasses}".TrimEnd();
+    }
+}

--- a/GdsBlazorComponents/GdsErrorSummary.razor
+++ b/GdsBlazorComponents/GdsErrorSummary.razor
@@ -2,7 +2,7 @@
 {
     <div class="govuk-error-summary" data-module="govuk-error-summary">
         <div role="alert">
-            <h2 class="govuk-error-summary__title">There is a problem</h2>
+            <GdsHeading Level="2" class="govuk-error-summary__title">There is a problem</GdsHeading>
             <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                     @foreach (var message in CurrentEditContext.GetValidationMessages())

--- a/GdsBlazorComponents/GdsFieldsetGroup.razor
+++ b/GdsBlazorComponents/GdsFieldsetGroup.razor
@@ -1,7 +1,7 @@
-﻿<fieldset class="govuk-fieldset" role="group" aria-describedby="@_describedBy">
+﻿<fieldset class="govuk-fieldset" role="group" aria-describedby="@_describedBy" @attributes="AdditionalAttributes">
     @if (Heading != null)
     {
-        <legend class="govuk-fieldset__legend @LegendSize.GetDescription()">
+        <legend class="@_legendClass">
             @Heading
         </legend>
     }
@@ -20,7 +20,7 @@
     private FieldIdentifier FieldIdentifier { get; set; } = default!;
 
     [Parameter]
-    public GdsFieldsetLegendSize LegendSize { get; set; } = GdsFieldsetLegendSize.Large;
+    public GdsSize LegendSize { get; set; } = GdsSize.Large;
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -31,5 +31,22 @@
     [Parameter]
     public RenderFragment? Content { get; set; }
 
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
     private string _describedBy => EditContext.IsValid(FieldIdentifier) ? $"{CascadedId}-hint" : $"{CascadedId}-hint {CascadedId}-error";
+    private string? _legendClass;
+
+    protected override void OnParametersSet()
+    {
+        var sizeClass = LegendSize switch
+        {
+            GdsSize.Small => "govuk-fieldset__legend--s",
+            GdsSize.Medium => "govuk-fieldset__legend--m",
+            GdsSize.Large => "govuk-fieldset__legend--l",
+            GdsSize.ExtraLarge => "govuk-fieldset__legend--xl",
+            _ => "govuk-fieldset__legend--l",
+        };
+        _legendClass = $"govuk-fieldset__legend {sizeClass}";
+    }
 }

--- a/GdsBlazorComponents/GdsFieldsetGroup.razor
+++ b/GdsBlazorComponents/GdsFieldsetGroup.razor
@@ -20,7 +20,10 @@
     private FieldIdentifier FieldIdentifier { get; set; } = default!;
 
     [Parameter]
-    public GdsSize LegendSize { get; set; } = GdsSize.Large;
+    [Obsolete("Deprecated in v3.3.0, use LegendTextSize instead.")]
+    public GdsFieldsetLegendSize? LegendSize { get; set; }
+    [Parameter]
+    public GdsSize LegendTextSize { get; set; } = GdsSize.Large;
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -39,7 +42,19 @@
 
     protected override void OnParametersSet()
     {
-        var sizeClass = LegendSize switch
+        // convert deprecated LegendSize to LegendTextSize if it has a value
+        var legendSize = LegendSize.HasValue
+            ? LegendSize.Value switch
+            {
+                GdsFieldsetLegendSize.Small => GdsSize.Small,
+                GdsFieldsetLegendSize.Medium => GdsSize.Medium,
+                GdsFieldsetLegendSize.Large => GdsSize.Large,
+                GdsFieldsetLegendSize.ExtraLarge => GdsSize.ExtraLarge,
+                _ => GdsSize.Large,
+            }
+            : LegendTextSize;
+
+        var sizeClass = legendSize switch
         {
             GdsSize.Small => "govuk-fieldset__legend--s",
             GdsSize.Medium => "govuk-fieldset__legend--m",

--- a/GdsBlazorComponents/GdsFieldsetLegendSize.cs
+++ b/GdsBlazorComponents/GdsFieldsetLegendSize.cs
@@ -1,18 +1,10 @@
-﻿using System.ComponentModel;
+﻿namespace GdsBlazorComponents;
 
-namespace GdsBlazorComponents;
-
+[Obsolete("This enum is deprecated. Use GdsSize instead.")]
 public enum GdsFieldsetLegendSize
 {
-	[Description("govuk-fieldset__legend--s")]
 	Small,
-
-	[Description("govuk-fieldset__legend--m")]
 	Medium,
-
-	[Description("govuk-fieldset__legend--l")]
 	Large,
-
-	[Description("govuk-fieldset__legend--xl")]
 	ExtraLarge,
 }

--- a/GdsBlazorComponents/GdsFooter.razor
+++ b/GdsBlazorComponents/GdsFooter.razor
@@ -1,5 +1,5 @@
 ﻿<footer class="@CssClass">
-    <div class="govuk-width-container">
+    <GdsContainer>
         @if (Navigation is not null)
         {
             <div class="govuk-footer__navigation">
@@ -16,7 +16,7 @@
                 @Meta
             </div>
         }
-    </div>
+    </GdsContainer>
 </footer>
 
 @code {

--- a/GdsBlazorComponents/GdsFooterSection.razor
+++ b/GdsBlazorComponents/GdsFooterSection.razor
@@ -1,0 +1,27 @@
+<GdsGridColumn AdditionalAttributes="@AdditionalAttributes" AdditionalCssClasses="@_class" Width="@Width" Widths="@Widths">
+    @ChildContent
+</GdsGridColumn>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public GdsGridColumnWidth? Width { get; set; }
+
+    [Parameter]
+    public GdsGridColumnWidth[] Widths { get; set; } = [];
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        _class = $"govuk-footer__section {AdditionalCssClasses}".TrimEnd();
+    }
+}

--- a/GdsBlazorComponents/GdsGridColumn.razor
+++ b/GdsBlazorComponents/GdsGridColumn.razor
@@ -1,0 +1,58 @@
+<div class="@_class" @attributes="AdditionalAttributes">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public GdsGridColumnWidth? Width { get; set; }
+
+    [Parameter]
+    public GdsGridColumnWidth[] Widths { get; set; } = [];
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        _class = $"{GetWidthCssClasses()} {AdditionalCssClasses}".TrimEnd();
+    }
+
+    private string GetWidthCssClasses()
+    {
+        if (Width is not null)
+        {
+            // Width specified, use it
+            var columnClass = Width.Value.GetDescription();
+            if (columnClass is not null)
+            {
+                return columnClass;
+            }
+        }
+
+        List<string> classes = [];
+        foreach (GdsGridColumnWidth columnWidth in Widths)
+        {
+            var columnClass = columnWidth.GetDescription();
+            if (columnClass is not null)
+            {
+                classes.Add(columnClass);
+            }
+        }
+        if (classes.Count > 0)
+        {
+            // Widths specified, use all of them
+            return string.Join(' ', classes);
+        }
+
+        // No widths specified, use default full width
+        return GdsGridColumnWidth.Full.GetDescription() ?? "";
+    }
+}

--- a/GdsBlazorComponents/GdsGridColumnWidth.cs
+++ b/GdsBlazorComponents/GdsGridColumnWidth.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel;
+
+namespace GdsBlazorComponents;
+
+public enum GdsGridColumnWidth
+{
+    [Description("govuk-grid-column-full")]
+    Full,
+
+    [Description("govuk-grid-column-one-half")]
+    OneHalf,
+
+    [Description("govuk-grid-column-one-half-from-desktop")]
+    OneHalfFromDesktop,
+
+    [Description("govuk-grid-column-one-third")]
+    OneThird,
+
+    [Description("govuk-grid-column-one-third-from-desktop")]
+    OneThirdFromDesktop,
+
+    [Description("govuk-grid-column-two-thirds")] 
+    TwoThirds,
+
+    [Description("govuk-grid-column-two-thirds-from-desktop")] 
+    TwoThirdsFromDesktop,
+
+    [Description("govuk-grid-column-one-quarter")]
+    OneQuarter,
+
+    [Description("govuk-grid-column-one-quarter-from-desktop")]
+    OneQuarterFromDesktop,
+
+    [Description("govuk-grid-column-three-quarters")]
+    ThreeQuarters,
+
+    [Description("govuk-grid-column-three-quarters-from-desktop")]
+    ThreeQuartersFromDesktop,
+}

--- a/GdsBlazorComponents/GdsGridRow.razor
+++ b/GdsBlazorComponents/GdsGridRow.razor
@@ -1,0 +1,21 @@
+<div class="@_class" @attributes="AdditionalAttributes">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        _class = $"govuk-grid-row {AdditionalCssClasses}".TrimEnd();
+    }
+}

--- a/GdsBlazorComponents/GdsHeader.razor
+++ b/GdsBlazorComponents/GdsHeader.razor
@@ -1,5 +1,5 @@
 ﻿<header class="govuk-header" role="banner" data-module="govuk-header">
-    <div class="govuk-header__container govuk-width-container">
+    <GdsContainer AdditionalCssClasses="govuk-header__container">
         <div class="govuk-header__logo">
             <a href="@ServiceUrl" class="govuk-header__link govuk-header__link--homepage">
                 <img src="@LogoUrl" alt="@ServiceName" height="40" class="govuk-header__logotype" />
@@ -17,7 +17,7 @@
                 </nav>
             </div>
         }
-    </div>
+    </GdsContainer>
 </header>
 
 @code {

--- a/GdsBlazorComponents/GdsHeading.razor
+++ b/GdsBlazorComponents/GdsHeading.razor
@@ -1,0 +1,53 @@
+@switch (Level)
+{
+    case 2:
+        <h2 class="@_class" @attributes="AdditionalAttributes">@ChildContent</h2>
+        break;
+    case 3:
+        <h3 class="@_class" @attributes="AdditionalAttributes">@ChildContent</h3>
+        break;
+    case 4:
+        <h4 class="@_class" @attributes="AdditionalAttributes">@ChildContent</h4>
+        break;
+    case 5:
+        <h5 class="@_class" @attributes="AdditionalAttributes">@ChildContent</h5>
+        break;
+    case 6:
+        <h6 class="@_class" @attributes="AdditionalAttributes">@ChildContent</h6>
+        break;
+    default:
+        <h1 class="@_class" @attributes="AdditionalAttributes">@ChildContent</h1>
+        break;
+}
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter, EditorRequired]
+    public byte Level { get; set; }
+
+    [Parameter]
+    public GdsSize Size { get; set; } = GdsSize.ExtraLarge;
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        string sizeClass = Size switch
+        {
+            GdsSize.Small => "govuk-heading-s",
+            GdsSize.Medium => "govuk-heading-m",
+            GdsSize.Large => "govuk-heading-l",
+            GdsSize.ExtraLarge => "govuk-heading-xl",
+            _ => "govuk-heading-xl",
+        };
+        _class = $"{sizeClass} {AdditionalCssClasses}".Trim();
+    }
+}

--- a/GdsBlazorComponents/GdsHeading.razor
+++ b/GdsBlazorComponents/GdsHeading.razor
@@ -30,17 +30,25 @@
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
+    /// <summary>
+    /// Heading level (1-6). This determines the HTML tag used (h1, h2, etc.) and the default size of the heading
+    /// </summary>
+    /// <remarks>Levels outside of 1-6 will default to h1 and the largest size</remarks>
     [Parameter, EditorRequired]
-    public byte Level { get; set; }
+    public int Level { get; set; }
 
+    /// <summary>
+    /// Size override for the heading. If not set, the size will be determined by the level of the heading (h1, h2, etc.)
+    /// </summary>
     [Parameter]
-    public GdsSize Size { get; set; } = GdsSize.ExtraLarge;
+    public GdsSize? Size { get; set; }
 
     private string? _class;
 
     protected override void OnParametersSet()
     {
-        string sizeClass = Size switch
+        var size = Size ?? AutomaticSize();
+        string sizeClass = size switch
         {
             GdsSize.Small => "govuk-heading-s",
             GdsSize.Medium => "govuk-heading-m",
@@ -49,5 +57,19 @@
             _ => "govuk-heading-xl",
         };
         _class = $"{sizeClass} {AdditionalCssClasses}".Trim();
+    }
+
+    protected GdsSize AutomaticSize()
+    {
+        return Level switch
+        {
+            1 => GdsSize.ExtraLarge,
+            2 => GdsSize.Large,
+            3 => GdsSize.Medium,
+            4 => GdsSize.Small,
+            5 => GdsSize.Small,
+            6 => GdsSize.Small,
+            _ => GdsSize.ExtraLarge,
+        };
     }
 }

--- a/GdsBlazorComponents/GdsMainWrapper.razor
+++ b/GdsBlazorComponents/GdsMainWrapper.razor
@@ -1,0 +1,26 @@
+<main class="@_class" @attributes="AdditionalAttributes" role="main">
+    @ChildContent
+</main>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public bool AutoSpacing { get; set; }
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        _class = AutoSpacing
+            ? $"govuk-main-wrapper govuk-main-wrapper--auto-spacing {AdditionalCssClasses}".TrimEnd()
+            : $"govuk-main-wrapper {AdditionalCssClasses}".TrimEnd();
+    }
+}

--- a/GdsBlazorComponents/GdsNotificationBanner.razor
+++ b/GdsBlazorComponents/GdsNotificationBanner.razor
@@ -1,16 +1,8 @@
 <div class="govuk-notification-banner @_class" role="@_role" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
     <div class="govuk-notification-banner__header">
-        @if (BannerTitleSize == BannerSizeOption.small)
-        {
-            <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                @BannerTitle
-            </h3>
-        } else
-        {
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                @BannerTitle
-            </h2>
-        }
+        <GdsHeading Level="@(BannerTitleSize == BannerSizeOption.small ? 3 : 2)" class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            @BannerTitle
+        </GdsHeading>
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">

--- a/GdsBlazorComponents/GdsPanel.razor
+++ b/GdsBlazorComponents/GdsPanel.razor
@@ -1,9 +1,9 @@
 ﻿<div class="@($"govuk-panel govuk-panel--confirmation {AdditionalCssClasses}")" @attributes="@AdditionalAttributes">
 	@if (!string.IsNullOrEmpty(Title))
 	{
-		<h1 class="govuk-panel__title">
-			@Title
-		</h1>
+        <GdsHeading Level="1" class="govuk-panel__title">
+            @Title
+		</GdsHeading>
 	}
 
 	@if (ChildContent is not null)

--- a/GdsBlazorComponents/GdsSize.cs
+++ b/GdsBlazorComponents/GdsSize.cs
@@ -1,0 +1,9 @@
+﻿namespace GdsBlazorComponents;
+
+public enum GdsSize
+{
+    Small = 10,
+    Medium = 20,
+    Large = 30,
+    ExtraLarge = 40,
+}

--- a/GdsBlazorComponents/GdsTabPanel.razor
+++ b/GdsBlazorComponents/GdsTabPanel.razor
@@ -1,7 +1,7 @@
 ﻿@implements IDisposable
 
 <div class="@($"govuk-tabs__panel {( Parent is not null && !Parent.IsFirst(this) ? "govuk-tabs__panel--hidden" : string.Empty )} {AdditionalCssClasses}")" id="@Id" @attributes="AdditionalAttributes">
-    <h2 class="@HeadingClass">@Heading</h2>
+    <GdsHeading Level="2" class="@HeadingClass">@Heading</GdsHeading>
     @ChildContent
 </div>
 

--- a/GdsBlazorComponents/GdsTable.razor
+++ b/GdsBlazorComponents/GdsTable.razor
@@ -39,7 +39,10 @@
 	public string? Caption { get; set; }
 
 	[Parameter]
-	public GdsSize CaptionSize { get; set; } = GdsSize.Large;
+	[Obsolete("Deprecated in v3.3.0, use CaptionTextSize instead.")]
+	public GdsTableCaptionSize? CaptionSize { get; set; }
+	[Parameter]
+	public GdsSize CaptionTextSize { get; set; } = GdsSize.Large;
 
 	[Parameter]
 	public bool FirstCellIsHeader { get; set; }
@@ -62,7 +65,19 @@
 
 	protected override void OnParametersSet()
 	{
-		var sizeClass = CaptionSize switch
+        // convert deprecated CaptionSize to CaptionTextSize if it has a value
+        var captionSize = CaptionSize.HasValue
+            ? CaptionSize.Value switch
+            {
+                GdsTableCaptionSize.Small => GdsSize.Small,
+                GdsTableCaptionSize.Medium => GdsSize.Medium,
+                GdsTableCaptionSize.Large => GdsSize.Large,
+                GdsTableCaptionSize.ExtraLarge => GdsSize.ExtraLarge,
+                _ => GdsSize.Large,
+            }
+            : CaptionTextSize;
+
+		var sizeClass = captionSize switch
 		{
 			GdsSize.Small => "govuk-table__caption--s",
 			GdsSize.Medium => "govuk-table__caption--m",

--- a/GdsBlazorComponents/GdsTable.razor
+++ b/GdsBlazorComponents/GdsTable.razor
@@ -3,7 +3,7 @@
 <table class="@($"govuk-table {Density.GetDescription()} {AdditionalTableCssClasses}")" @attributes="@AdditionalAttributes">
 	@if (!string.IsNullOrEmpty(Caption))
 	{
-		<caption class="@($"govuk-table__caption {CaptionSize.GetDescription()} {AdditionalCaptionCssClasses}")">@Caption</caption>
+		<caption class="@_captionClass">@Caption</caption>
 	}
 
 	@if (HeaderContent is not null)
@@ -39,7 +39,7 @@
 	public string? Caption { get; set; }
 
 	[Parameter]
-	public GdsTableCaptionSize CaptionSize { get; set; } = GdsTableCaptionSize.Default;
+	public GdsSize CaptionSize { get; set; } = GdsSize.Large;
 
 	[Parameter]
 	public bool FirstCellIsHeader { get; set; }
@@ -57,4 +57,19 @@
 	public RenderFragment? HeaderContent { get; set; }
 	[Parameter]
 	public RenderFragment<T>? RowTemplate { get; set; }
+
+	private string? _captionClass;
+
+	protected override void OnParametersSet()
+	{
+		var sizeClass = CaptionSize switch
+		{
+			GdsSize.Small => "govuk-table__caption--s",
+			GdsSize.Medium => "govuk-table__caption--m",
+			GdsSize.Large => "govuk-table__caption--l",
+			GdsSize.ExtraLarge => "govuk-table__caption--xl",
+			_ => "govuk-table__caption--l",
+		};
+		_captionClass = $"govuk-table__caption {sizeClass} {AdditionalCaptionCssClasses}".TrimEnd();
+	}
 }

--- a/GdsBlazorComponents/GdsTableCaptionSize.cs
+++ b/GdsBlazorComponents/GdsTableCaptionSize.cs
@@ -1,20 +1,11 @@
-﻿using System.ComponentModel;
+﻿namespace GdsBlazorComponents;
 
-namespace GdsBlazorComponents;
-
+[Obsolete("This enum is deprecated. Use GdsSize instead.")]
 public enum GdsTableCaptionSize
 {
 	Default,
-
-	[Description("govuk-table__caption--s")]
 	Small,
-
-	[Description("govuk-table__caption--m")]
 	Medium,
-
-	[Description("govuk-table__caption--l")]
 	Large,
-
-	[Description("govuk-table__caption--xl")]
 	ExtraLarge,
 }

--- a/GdsBlazorComponents/GdsTabs.razor
+++ b/GdsBlazorComponents/GdsTabs.razor
@@ -1,8 +1,8 @@
 ﻿<CascadingValue Value="this" IsFixed="true">
     <div class="@($"govuk-tabs {AdditionalCssClasses}")" data-module="govuk-tabs" @attributes="@AdditionalAttributes">
-        <h2 class="govuk-tabs__title">
+        <GdsHeading Level="2" class="govuk-tabs__title">
             @Title
-        </h2>
+        </GdsHeading>
 
         @if (panels.Count > 0)
         {

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Actual code samples can be found in this repo alongside each component.
 - [GdsGridRow](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridRow.md)
 - [GdsGridColumn](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridColumn.md)
 - [GdsHeader](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Header.md)
+- [GdsHeading](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Heading.md)
 - [GdsHint](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Hint.md)
 - [GdsInputDate](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/InputDate.md)
 - [GdsInputNumber](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/InputNumber.md)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Actual code samples can be found in this repo alongside each component.
 - [GdsFileInput](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FileInput.md)
 - [GdsFooter](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Footer.md)
 - [GdsFormGroup](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FormGroup.md)
+- [GdsGridRow](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridRow.md)
 - [GdsHeader](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Header.md)
 - [GdsHint](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Hint.md)
 - [GdsInputDate](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/InputDate.md)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Actual code samples can be found in this repo alongside each component.
 - [GdsInputText](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/InputText.md)
 - [GdsInsetText](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/InsetText.md)
 - [GdsLabel](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Label.md)
+- [GdsMainWrapper](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/MainWrapper.md)
 - [GdsNotificationBanner](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/NotificationBanner.md)
 - [GdsPhaseBanner](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/PhaseBanner.md)
 - [GdsRadio](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Radio.md)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Actual code samples can be found in this repo alongside each component.
 - [GdsButton](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Button.md)
 - [GdsCheckbox](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Checkbox.md)
 - [GdsCheckboxes](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Checkboxes.md)
+- [GdsContainer](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Container.md)
 - [GdsErrorMessage](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/ErrorMessage.md)
 - [GdsErrorSummary](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/ErrorSummary.md)
 - [GdsFieldsetGroup](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FieldsetGroup.md)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Actual code samples can be found in this repo alongside each component.
 - [GdsFooter](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Footer.md)
 - [GdsFormGroup](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FormGroup.md)
 - [GdsGridRow](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridRow.md)
+- [GdsGridColumn](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridColumn.md)
 - [GdsHeader](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Header.md)
 - [GdsHint](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Hint.md)
 - [GdsInputDate](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/InputDate.md)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Actual code samples can be found in this repo alongside each component.
 - [GdsFieldsetGroup](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FieldsetGroup.md)
 - [GdsFileInput](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FileInput.md)
 - [GdsFooter](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/Footer.md)
+- [GdsFooterSection](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FooterSection.md)
 - [GdsFormGroup](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/FormGroup.md)
 - [GdsGridRow](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridRow.md)
 - [GdsGridColumn](https://github.com/Dorset-Council-UK/GdsBlazorComponents/blob/main/GdsBlazorComponents/Examples/GridColumn.md)


### PR DESCRIPTION
- resolves #88 
- version 3.3.0
- new GdsContainer component
- new GdsGridRow component
- new GdsGridColumn component
- new GdsFooterSection component
- new GdsMainWrapper component
- new GdsHeading component
- new GdsSize enum
- Deprecated enum GdsFieldsetLegendSize use GdsSize instead.
- Deprecated enum GdsTableCaptionSize use GdsSize instead.
- new example files for:
  - container
  - footer section
  - grid column
  - grid row
  - heading
  - main wrapper
- updated a lot of example files to use the new components over HTML

Sizes were starting to be used in multiple places so created a single GdsSize enum with CSS classes being calculated in each component.
