### PR TITLE
Bugfix fieldset group

### DIFF
--- a/GdsBlazorComponents/Examples/Checkboxes.md
+++ b/GdsBlazorComponents/Examples/Checkboxes.md
@@ -48,14 +48,13 @@ ICollection<GdsOptionItem<int>> contactTypes = [
 ];
 <GdsFormGroup For="() => Model.ContactType">
     <GdsFieldsetGroup>
-        <Heading>
-            <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
-        </Heading>
-        <Content>
-            <GdsHint>Select all that apply.</GdsHint>
-            <GdsErrorMessage />
-            <GdsCheckboxes Options="@contactTypes" Name="ContactTypes" />
-        </Content>
+        <GdsFieldsetLegend>
+            <GdsFieldsetHeading Level="2">How can we contact you?</GdsFieldsetHeading>
+        </GdsFieldsetLegend>
+
+        <GdsHint>Select all that apply.</GdsHint>
+        <GdsErrorMessage />
+        <GdsCheckboxes Options="@contactTypes" Name="ContactTypes" />
     </GdsFieldsetGroup>
 </GdsFormGroup>
 ```
@@ -71,30 +70,29 @@ ICollection<GdsOptionItem<int>> contactTypes = [
 ];
 <GdsFormGroup For="() => Model.ContactType">
     <GdsFieldsetGroup>
-        <Heading>
-            <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
-        </Heading>
-        <Content>
-            <GdsHint>Select all that apply.</GdsHint>
-            <GdsErrorMessage />
-            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                @foreach (var option in contactTypes)
+        <GdsFieldsetLegend>
+            <GdsFieldsetHeading Level="2">How can we contact you?</GdsFieldsetHeading>
+        </GdsFieldsetLegend>
+
+        <GdsHint>Select all that apply.</GdsHint>
+        <GdsErrorMessage />
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+            @foreach (var option in contactTypes)
+            {
+                var conditionalId = option.Value == 1 ? $"{option.Id}-conditional" : null;
+                <GdsCheckbox Option="@option" ConditionalId="@conditionalId" Name="ContactTypes" />
+                if (option.Value == 1)
                 {
-                    var conditionalId = option.Value == 1 ? $"{option.Id}-conditional" : null;
-                    <GdsCheckbox Option="@option" ConditionalId="@conditionalId" Name="ContactTypes" />
-                    if (option.Value == 1)
-                    {
-                        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="@conditionalId">
-                            <GdsFormGroup For="() => Model.PhoneNumber">
-                                <GdsLabel Text="What is your phone number?" />
-                                <GdsErrorMessage />
-                                <GdsInputText @bind-Value=Model.PhoneNumber class="govuk-input govuk-input--width-50" />
-                            </GdsFormGroup>
-                        </div>
-                    }
+                    <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="@conditionalId">
+                        <GdsFormGroup For="() => Model.PhoneNumber">
+                            <GdsLabel Text="What is your phone number?" />
+                            <GdsErrorMessage />
+                            <GdsInputText @bind-Value=Model.PhoneNumber class="govuk-input govuk-input--width-50" />
+                        </GdsFormGroup>
+                    </div>
                 }
-            </div>
-        </Content>
+            }
+        </div>
     </GdsFieldsetGroup>
 </GdsFormGroup>
 ```

--- a/GdsBlazorComponents/Examples/FieldsetGroup.md
+++ b/GdsBlazorComponents/Examples/FieldsetGroup.md
@@ -5,9 +5,8 @@ Render a GOV.UK Design System styled fieldset that associates with a form contro
 ## How it works
 
 - Renders ```<fieldset class="govuk-fieldset">``` with any child content you provide.
-- An optional heading can be provided using the `Heading` parameter.
-  - This will be wrapped in a legend element with the correct GDS classes.
-  - You can change the size of the legend using the `LegendTextSize` parameter.
+- Use `GdsFieldsetLegend` to provide a legend for the fieldset.
+- Optionally use `GdsFieldsetHeading` to provide a heading for the legend.
 - The component tries to calculate aria-describedby based on hint and field errors.
 - It is recommended to use this component within a [GdsFormGroup](FormGroup.md) to fully support correct HTML and accessibility.
 
@@ -19,21 +18,20 @@ See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examp
 
 ```csharp
 <GdsFieldsetGroup>
-    <Heading>
-        <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
-    </Heading>
+    <GdsFieldsetLegend Size="@GdsSize.Large">
+        How can we contact you?
+    </GdsFieldsetLegend>
+    <div>Your content goes here</div>
 </GdsFieldsetGroup>
 ```
 
-## Example
+## Example with heading
 
 ```csharp
 <GdsFieldsetGroup LegendTextSize="GdsSize.Medium">
-    <Heading>
-        <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
-    </Heading>
-    <Content>
-        <div>Anything can go here.</div>
-    </Content>
+    <GdsFieldsetLegend Size="@GdsSize.Medium">
+        <GdsFieldsetHeading Level="2">How can we contact you?</GdsFieldsetHeading>
+    </GdsFieldsetLegend>
+    <div>Your content goes here</div>
 </GdsFieldsetGroup>
 ```

--- a/GdsBlazorComponents/Examples/FieldsetGroup.md
+++ b/GdsBlazorComponents/Examples/FieldsetGroup.md
@@ -10,15 +10,18 @@ Render a GOV.UK Design System styled fieldset that associates with a form contro
 - The component tries to calculate aria-describedby based on hint and field errors.
 - It is recommended to use this component within a [GdsFormGroup](FormGroup.md) to fully support correct HTML and accessibility.
 
-*Warning:* `LegendSize` was deprecated in version 3.3.0 use `LegendTextSize` instead. `LegendSize` will be removed in a future release.
-
 See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examples of using this component.
+
+## Warning
+`LegendSize` was deprecated in version 3.3.0 `LegendSize` will be removed in a future release.
+
+Use `GdsFieldsetLegend` with the `Size` parameter instead. 
 
 ## Simple example
 
 ```csharp
 <GdsFieldsetGroup>
-    <GdsFieldsetLegend Size="@GdsSize.Large">
+    <GdsFieldsetLegend>
         How can we contact you?
     </GdsFieldsetLegend>
     <div>Your content goes here</div>
@@ -28,7 +31,7 @@ See [GdsCheckboxes](Checkboxes.md) and [GdsRadios](Radios.md) for complete examp
 ## Example with heading
 
 ```csharp
-<GdsFieldsetGroup LegendTextSize="GdsSize.Medium">
+<GdsFieldsetGroup>
     <GdsFieldsetLegend Size="@GdsSize.Medium">
         <GdsFieldsetHeading Level="2">How can we contact you?</GdsFieldsetHeading>
     </GdsFieldsetLegend>

--- a/GdsBlazorComponents/Examples/Radios.md
+++ b/GdsBlazorComponents/Examples/Radios.md
@@ -58,14 +58,13 @@ ICollection<GdsOptionItem<int>> contactTypes = [
 <GdsFormGroup For="() => Model.ContactType">
     <InputRadioGroup @bind-Value="Model.ContactType">
         <GdsFieldsetGroup>
-            <Heading>
-                <GdsHeading Level="2" class="govuk-fieldset__heading">How can we contact you?</GdsHeading>
-            </Heading>
-            <Content>
-                <GdsHint>Select all that apply.</GdsHint>
-                <GdsErrorMessage />
-                <GdsRadios Options="@contactTypes" />
-            </Content>
+            <GdsFieldsetLegend Size="@GdsSize.Medium">
+                <GdsFieldsetHeading Level="2">How can we contact you?</GdsFieldsetHeading>
+            </GdsFieldsetLegend>
+
+            <GdsHint>Select all that apply.</GdsHint>
+            <GdsErrorMessage />
+            <GdsRadios Options="@contactTypes" />
         </GdsFieldsetGroup>
     </InputRadioGroup>
 </GdsFormGroup>

--- a/GdsBlazorComponents/GdsFieldsetGroup.razor
+++ b/GdsBlazorComponents/GdsFieldsetGroup.razor
@@ -1,9 +1,9 @@
-﻿<fieldset class="govuk-fieldset" role="group" aria-describedby="@_describedBy" @attributes="AdditionalAttributes">
+﻿<fieldset class="@_class" role="group" aria-describedby="@_describedBy" @attributes="AdditionalAttributes">
     @if (Heading != null)
     {
-        <legend class="@_legendClass">
+        <GdsFieldsetLegend Size="@_legendSize">
             @Heading
-        </legend>
+        </GdsFieldsetLegend>
     }
     @ChildContent
     @Content
@@ -11,13 +11,13 @@
 
 @code {
     [CascadingParameter]
-    private EditContext EditContext { get; set; } = default!;
+    private EditContext? EditContext { get; set; }
 
     [CascadingParameter]
     private string? CascadedId { get; set; }
 
     [CascadingParameter]
-    private FieldIdentifier FieldIdentifier { get; set; } = default!;
+    private FieldIdentifier? FieldIdentifier { get; set; }
 
     [Parameter]
     [Obsolete("Deprecated in v3.3.0, use LegendTextSize instead.")]
@@ -34,16 +34,20 @@
     [Parameter]
     public RenderFragment? Content { get; set; }
 
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string _describedBy => EditContext.IsValid(FieldIdentifier) ? $"{CascadedId}-hint" : $"{CascadedId}-hint {CascadedId}-error";
-    private string? _legendClass;
+    private string? _class;
+    private string? _describedBy;
+    private GdsSize _legendSize;
 
     protected override void OnParametersSet()
     {
         // convert deprecated LegendSize to LegendTextSize if it has a value
-        var legendSize = LegendSize.HasValue
+        _legendSize = LegendSize.HasValue
             ? LegendSize.Value switch
             {
                 GdsFieldsetLegendSize.Small => GdsSize.Small,
@@ -54,14 +58,25 @@
             }
             : LegendTextSize;
 
-        var sizeClass = legendSize switch
+        _class = $"govuk-fieldset {AdditionalCssClasses}".TrimEnd();
+        _describedBy = CalculateDescribedBy();
+    }
+
+    private string? CalculateDescribedBy()
+    {
+        if (string.IsNullOrWhiteSpace(CascadedId) || EditContext is null)
         {
-            GdsSize.Small => "govuk-fieldset__legend--s",
-            GdsSize.Medium => "govuk-fieldset__legend--m",
-            GdsSize.Large => "govuk-fieldset__legend--l",
-            GdsSize.ExtraLarge => "govuk-fieldset__legend--xl",
-            _ => "govuk-fieldset__legend--l",
-        };
-        _legendClass = $"govuk-fieldset__legend {sizeClass}";
+            return null;
+        }
+
+        string hintId = $"{CascadedId}-hint";
+        string errorId = $"{CascadedId}-error";
+
+        if (FieldIdentifier is null)
+        {
+            return $"{hintId} {errorId}";
+        }
+
+        return EditContext.IsValid(FieldIdentifier.Value) ? hintId : $"{hintId} {errorId}";
     }
 }

--- a/GdsBlazorComponents/GdsFieldsetGroup.razor
+++ b/GdsBlazorComponents/GdsFieldsetGroup.razor
@@ -44,6 +44,19 @@
     private string? _describedBy;
     private GdsSize _legendSize;
 
+    protected override void OnInitialized()
+    {
+        if (EditContext is not null)
+        {
+            // Subscribe to validation state changes
+            EditContext.OnValidationStateChanged += (sender, args) =>
+            {
+                _describedBy = CalculateDescribedBy();
+                StateHasChanged();
+            };
+        }
+    }
+
     protected override void OnParametersSet()
     {
         // convert deprecated LegendSize to LegendTextSize if it has a value

--- a/GdsBlazorComponents/GdsFieldsetHeading.razor
+++ b/GdsBlazorComponents/GdsFieldsetHeading.razor
@@ -1,0 +1,34 @@
+<GdsHeading Level="@Level" class="@_class" @attributes="AdditionalAttributes">
+    @ChildContent
+</GdsHeading>
+
+@code {
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>
+    /// Heading level (1-6). This determines the HTML tag used (h1, h2, etc.) and the default size of the heading
+    /// </summary>
+    /// <remarks>Levels outside of 1-6 will default to h1 and the largest size</remarks>
+    [Parameter, EditorRequired]
+    public int Level { get; set; }
+
+    /// <summary>
+    /// Size override for the heading. If not set, the size will be determined by the level of the heading (h1, h2, etc.)
+    /// </summary>
+    [Parameter]
+    public GdsSize? Size { get; set; }
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        _class = $"govuk-fieldset__heading {AdditionalCssClasses}".TrimEnd();
+    }
+}

--- a/GdsBlazorComponents/GdsFieldsetLegend.razor
+++ b/GdsBlazorComponents/GdsFieldsetLegend.razor
@@ -1,0 +1,32 @@
+<legend class="@_class" @attributes="AdditionalAttributes">
+    @ChildContent
+</legend>
+
+@code {
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; }
+
+    [Parameter]
+    public string? AdditionalCssClasses { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public GdsSize? Size { get; set; }
+
+    private string? _class;
+
+    protected override void OnParametersSet()
+    {
+        string sizeClass = Size switch
+        {
+            GdsSize.Small => "govuk-fieldset__legend--s",
+            GdsSize.Medium => "govuk-fieldset__legend--m",
+            GdsSize.Large => "govuk-fieldset__legend--l",
+            GdsSize.ExtraLarge => "govuk-fieldset__legend--xl",
+            _ => "govuk-fieldset__legend--l",
+        };
+        _class = $"govuk-fieldset__legend {sizeClass} {AdditionalCssClasses}".TrimEnd();
+    }
+}


### PR DESCRIPTION
- resolves #92 
- fixed the bug
  - edit context is optional
  - field identifier is optional
  - robust aria described by building
- new AdditionalCssClasses parameter
- new fieldset heading component
- new fieldset legend component
- the new components mean the Heading and Content sections don't have to be used. Still works with them
- updated all examples using GdsFieldsetGroup

**Notes:**
Version number to be incremented later with other component changes