### PR TITLE
Update build.yml for NuGet trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # enable GitHub OIDC token issuance for this job
 
 jobs:
   build:
@@ -56,4 +57,11 @@ jobs:
         with:
           name: nuget-package
 
-      - run: dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate --no-symbols
+      # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{secrets.NUGET_USER}} # Recommended: use a secret like ${{ secrets.NUGET_USER }} for your nuget.org username (profile name), NOT your email address
+    
+      - run: dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{steps.login.outputs.NUGET_API_KEY}} --skip-duplicate --no-symbols

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # enable GitHub OIDC token issuance for this job
 
 jobs:
   build:
@@ -45,6 +44,8 @@ jobs:
     needs: build
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # enable GitHub OIDC token issuance for this job
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write  # enable GitHub OIDC token issuance for this job
 
     steps:


### PR DESCRIPTION
This PR updates the CI/CD pipeline to use the new [Trusted Publishing](https://aka.ms/nuget/trusted-publishing) method.